### PR TITLE
PLATFORM-4871 | Add ParserAllowExternalImage hook in Parser::maybeMakeExternalImage method

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -2129,17 +2129,24 @@ class Parser {
 			$imagematch = false;
 		}
 
+		// Fandom change - start (@author ttomalak)
+		// allow fandom image links PLATFORM-4871
+		$allowed = Hooks::isRegistered( 'ParserAllowExternalImage' )
+				   && Hooks::run( 'ParserAllowExternalImage', [ $url ] );
+
 		if ( $this->mOptions->getAllowExternalImages()
-			|| ( $imagesexception && $imagematch )
+			 || $allowed
+			 || ( $imagesexception && $imagematch )
 		) {
-			if ( preg_match( self::EXT_IMAGE_REGEX, $url ) ) {
+			if ( preg_match( self::EXT_IMAGE_REGEX, $url ) || $allowed ) {
 				# Image found
 				$text = Linker::makeExternalImage( $url );
 			}
 		}
 		if ( !$text && $this->mOptions->getEnableImageWhitelist()
-			&& preg_match( self::EXT_IMAGE_REGEX, $url )
+			 && ( preg_match( self::EXT_IMAGE_REGEX, $url ) || $allowed )
 		) {
+			// Fandom change - end
 			$whitelist = explode(
 				"\n",
 				wfMessage( 'external_image_whitelist' )->inContentLanguage()->text()


### PR DESCRIPTION
Currently `Parser` allows only hot linking images with `.jpg|.jpeg|.png|.gif` in the end of url. As we use revision, version and query params in our Vignette urls, they would not be allowed for render even if domain was added to `wgAllowExternalImagesFrom`. `ParserAllowExternalImage` hook will be used only if domain in image url is added to `wgAllowExternalImagesFrom` list or `wgAllowExternalImages` is set to `true`.