### PR TITLE
MAIN-20976 | Backport ContribsPager query optimization patches

### DIFF
--- a/RELEASE-NOTES-1.33
+++ b/RELEASE-NOTES-1.33
@@ -5,6 +5,8 @@ THIS IS NOT A RELEASE YET
 === Changes since MediaWiki 1.33.3 ===
 
 * The MultiHttpClient code will fallover to non-curl if curl_multi* is blocked.
+* Per-user concurrency in SpecialContributions can now be limited by setting
+  $wgPoolCounterConf['SpecialContributions'] appropriately.
 
 == MediaWiki 1.33.3 ==
 

--- a/includes/specials/SpecialContributions.php
+++ b/includes/specials/SpecialContributions.php
@@ -236,19 +236,38 @@ class SpecialContributions extends IncludableSpecialPage {
 			} elseif ( !$pager->getNumRows() ) {
 				$out->addWikiMsg( 'nocontribs', $target );
 			} else {
-				# Show a message about replica DB lag, if applicable
-				$lag = $pager->getDatabase()->getSessionLagStatus()['lag'];
-				if ( $lag > 0 ) {
-					$out->showLagWarning( $lag );
+				// @todo We just want a wiki ID here, not a "DB domain", but
+				// current status of MediaWiki conflates the two. See T235955.
+				$poolKey = WikiMap::getCurrentWikiDbDomain() . ':SpecialContributions:';
+				if ( $this->getUser()->isAnon() ) {
+					$poolKey .= 'a:' . $this->getUser()->getName();
+				} else {
+					$poolKey .= 'u:' . $this->getUser()->getId();
 				}
+				$work = new PoolCounterWorkViaCallback( 'SpecialContributions', $poolKey, [
+					'doWork' => function () use ( $pager, $out ) {
+						# Show a message about replica DB lag, if applicable
+						$lag = $pager->getDatabase()->getSessionLagStatus()['lag'];
+						if ( $lag > 0 ) {
+							$out->showLagWarning( $lag );
+						}
 
-				$output = $pager->getBody();
-				if ( !$this->including() ) {
-					$output = $pager->getNavigationBar() .
-						$output .
-						$pager->getNavigationBar();
-				}
-				$out->addHTML( $output );
+						$output = $pager->getBody();
+						if ( !$this->including() ) {
+							$output = $pager->getNavigationBar() .
+								$output .
+								$pager->getNavigationBar();
+						}
+						$out->addHTML( $output );
+					},
+					'error' => function () use ( $out ) {
+						$msg = $this->getUser()->isAnon()
+							? 'sp-contributions-concurrency-ip'
+							: 'sp-contributions-concurrency-user';
+						$out->wrapWikiMsg( "<div class='errorbox'>\n$1\n</div>", $msg );
+					}
+				] );
+				$work->execute();
 			}
 
 			$out->preventClickjacking( $pager->getPreventClickjacking() );

--- a/includes/specials/pagers/ContribsPager.php
+++ b/includes/specials/pagers/ContribsPager.php
@@ -319,9 +319,6 @@ class ContribsPager extends RangeChronologicalPager {
 				if ( isset( $conds['orconds']['actor'] ) ) {
 					// @todo: This will need changing when revision_actor_temp goes away
 					$queryInfo['options']['USE INDEX']['temp_rev_user'] = 'actor_timestamp';
-				} else {
-					$queryInfo['options']['USE INDEX']['revision'] =
-						isset( $conds['orconds']['userid'] ) ? 'user_timestamp' : 'usertext_timestamp';
 				}
 			}
 		}

--- a/includes/specials/pagers/ContribsPager.php
+++ b/includes/specials/pagers/ContribsPager.php
@@ -301,11 +301,12 @@ class ContribsPager extends RangeChronologicalPager {
 				if ( isset( $conds['orconds']['actor'] ) ) {
 					// @todo: This will need changing when revision_comment_temp goes away
 					$queryInfo['options']['USE INDEX']['temp_rev_user'] = 'actor_timestamp';
-					// Alias 'rev_timestamp' => 'revactor_timestamp' so "ORDER BY rev_timestamp" is interpreted to
-					// use revactor_timestamp instead.
+					// Alias 'rev_timestamp' => 'revactor_timestamp' and 'rev_id' => 'revactor_rev' so
+					// "ORDER BY rev_timestamp, rev_id" is interpreted to use denormalized revision_actor_temp
+					// fields instead.
 					$queryInfo['fields'] = array_merge(
-						array_diff( $queryInfo['fields'], [ 'rev_timestamp' ] ),
-						[ 'rev_timestamp' => 'revactor_timestamp' ]
+						array_diff( $queryInfo['fields'], [ 'rev_timestamp', 'rev_id' ] ),
+						[ 'rev_timestamp' => 'revactor_timestamp', 'rev_id' => 'revactor_rev' ]
 					);
 				} else {
 					$queryInfo['options']['USE INDEX']['revision'] =

--- a/languages/i18n/en.json
+++ b/languages/i18n/en.json
@@ -2568,6 +2568,8 @@
 	"sp-contributions-footer-anon-range": "-",
 	"sp-contributions-footer-newbies": "-",
 	"sp-contributions-outofrange": "Unable to show any results. The requested IP range is larger than the CIDR limit of /$1.",
+	"sp-contributions-concurrency-user": "Sorry, too many requests are being made from your user account. Please try again later.",
+	"sp-contributions-concurrency-ip": "Sorry, too many requests are being made from your IP address. Please try again later.",
 	"whatlinkshere": "What links here",
 	"whatlinkshere-title": "Pages that link to \"$1\"",
 	"whatlinkshere-summary": "",

--- a/languages/i18n/qqq.json
+++ b/languages/i18n/qqq.json
@@ -2774,6 +2774,8 @@
 	"sp-contributions-footer-anon-range": "{{ignored}}This is the footer for IP ranges on [[Special:Contributions]].",
 	"sp-contributions-footer-newbies": "{{ignored}}This is the footer for newbie users on [[Special:Contributions]].",
 	"sp-contributions-outofrange": "Message shown when a user tries to view contributions of an IP range that's too large. $1 is the numerical limit imposed on the CIDR range.",
+	"sp-contributions-concurrency-user": "Message shown when a logged-in user tries to load [[Special:Contributions]] too many times at once.",
+	"sp-contributions-concurrency-ip": "Message shown when a logged-out user tries to load [[Special:Contributions]] too many times at once.",
 	"whatlinkshere": "The text of the link in the toolbox (on the left, below the search menu) going to [[Special:WhatLinksHere]].\n\nSee also:\n* {{msg-mw|Whatlinkshere}}\n* {{msg-mw|Accesskey-t-whatlinkshere}}\n* {{msg-mw|Tooltip-t-whatlinkshere}}",
 	"whatlinkshere-title": "Title of the special page [[Special:WhatLinksHere]]. This page appears when you click on the 'What links here' button in the toolbox. $1 is the name of the page concerned.",
 	"whatlinkshere-summary": "{{doc-specialpagesummary|whatlinkshere}}",

--- a/tests/phpunit/includes/specials/ContribsPagerTest.php
+++ b/tests/phpunit/includes/specials/ContribsPagerTest.php
@@ -158,9 +158,7 @@ class ContribsPagerTest extends MediaWikiTestCase {
 
 		$this->assertContains( 'ip_changes', $queryInfo[0] );
 		$this->assertArrayHasKey( 'ip_changes', $queryInfo[5] );
-		$this->assertSame( 'ipc_rev_timestamp', $queryInfo[1]['rev_timestamp'] );
-		$this->assertSame( 'ipc_rev_id', $queryInfo[1]['rev_id'] );
-		$this->assertSame( [ 'rev_timestamp DESC', 'rev_id DESC' ], $queryInfo[4]['ORDER BY'] );
+		$this->assertSame( [ 'ipc_rev_timestamp DESC', 'ipc_rev_id DESC' ], $queryInfo[4]['ORDER BY'] );
 	}
 
 }


### PR DESCRIPTION
Backport a set of upstream patches to improve ContribsPager query performance:
* https://gerrit.wikimedia.org/r/c/mediawiki/core/+/505814 and https://gerrit.wikimedia.org/r/c/mediawiki/core/+/504021  to address [T221380](https://phabricator.wikimedia.org/T221380) and [T220991](https://phabricator.wikimedia.org/T220991) by ensuring that ContribsPager uses denormalized timestamp and ID fields for ordering and pagination.
* https://gerrit.wikimedia.org/r/c/mediawiki/core/+/598887 to remove index forcing on `user_timestamp` in ContribsPager that forces the query planner into a suboptimal execution path on wikis where actor migration isn't reading the new schema.
* https://gerrit.wikimedia.org/r/c/mediawiki/core/+/551909 to allow limiting concurrent access to Contributions via PoolCounter.