### PR TITLE
MessageCache: Replace internal loadedLanguages array with special cac…

### DIFF
--- a/includes/cache/MessageCache.php
+++ b/includes/cache/MessageCache.php
@@ -99,12 +99,6 @@ class MessageCache {
 	protected $contLang;
 
 	/**
-	 * Track which languages have been loaded by load().
-	 * @var array
-	 */
-	private $loadedLanguages = [];
-
-	/**
 	 * Singleton instance
 	 *
 	 * @var MessageCache $instance
@@ -112,7 +106,7 @@ class MessageCache {
 	private static $instance;
 
 	/**
-	 * Get the signleton instance of this class
+	 * Get the singleton instance of this class
 	 *
 	 * @since 1.18
 	 * @return MessageCache
@@ -270,7 +264,7 @@ class MessageCache {
 		}
 
 		# Don't do double loading...
-		if ( isset( $this->loadedLanguages[$code] ) && $mode != self::FOR_UPDATE ) {
+		if ( $this->isLanguageLoaded( $code ) && $mode != self::FOR_UPDATE ) {
 			return true;
 		}
 
@@ -391,12 +385,9 @@ class MessageCache {
 			wfDebugLog( 'MessageCacheError', __METHOD__ . ": Failed to load $code\n" );
 			# This used to throw an exception, but that led to nasty side effects like
 			# the whole wiki being instantly down if the memcached server died
-		} else {
-			# All good, just record the success
-			$this->loadedLanguages[$code] = true;
 		}
 
-		if ( !$this->cache->has( $code ) ) { // sanity
+		if ( !$this->isLanguageLoaded( $code ) ) { // sanity
 			throw new LogicException( "Process cache for '$code' should be set by now." );
 		}
 
@@ -585,6 +576,22 @@ class MessageCache {
 		unset( $cache['EXCESSIVE'] ); // only needed for hash
 
 		return $cache;
+	}
+
+	/**
+	 * Whether the language was loaded and its data is still in the process cache.
+	 *
+	 * @param string $lang
+	 * @return bool
+	 */
+	private function isLanguageLoaded( $lang ) {
+		// It is important that this only returns true if the cache was fully
+		// populated by load(), so that callers can assume all cache keys exist.
+		// It is possible for $this->cache to be only patially populated through
+		// methods like MessageCache::replace(), which must not make this method
+		// return true (T208897). And this method must cease to return true
+		// if the language was evicted by MapCacheLRU (T230690).
+		return $this->cache->hasField( $lang, 'VERSION' );
 	}
 
 	/**
@@ -1299,7 +1306,6 @@ class MessageCache {
 			$this->wanCache->touchCheckKey( $this->getCheckKey( $code ) );
 		}
 		$this->cache->clear();
-		$this->loadedLanguages = [];
 	}
 
 	/**


### PR DESCRIPTION
…he key

Before c962b480568ea, the 'loadedLanguages' array was used to track
which languages were loaded and in the cache, with 'cache' being a
simple array. In that commit, the 'cache' array also started being used
for incomplete datasets, which didn't affect 'loadedLanguages'.

Then in 97e86d934b348, the 'loadedLanguages' array was removed in favour
of checking keys on 'cache' directly, and 'cache' was converted to
MapCacheLRU.

This led to problem where partially loaded data was mistaken for being
full datasets (fatal error, T208897). This was fixed in a5c984cc5978f86,
by bringing back the 'loadedLanguages' array, which fixed the issue from
the POV of partially loaded data.

However, this then exposed a new problem. The 'cache' data can be evicted
by MapCacheLRU, whereas 'loadedLanguages' is not aware of that. Thus it
claims languages are loaded that sometimes aren't. (This only affects web
requests where more than 5 language codes are involved, per MapCacheLRU.)

Fix this by re-removing the 'loadedLanguages' array, this time
strengthening the 'cache' key check to not just check that the root key
exists, but that it is in fact holding the full dataset as generated by
MessageCache::load(). The 'VERSION' key appears to be a good proxy for
that.

Bug: T230690
Change-Id: I1162a3857376aa37e5894ae3c8be84a2295782a3
(cherry-picked from 67f3df57)

https://wikia-inc.atlassian.net/browse/GPUCP-636