### PR TITLE
PLATFORM-5236 | Fix infinite loop in the FixDefaultJsonContentPages job

### DIFF
--- a/maintenance/fixDefaultJsonContentPages.php
+++ b/maintenance/fixDefaultJsonContentPages.php
@@ -68,6 +68,7 @@ class FixDefaultJsonContentPages extends LoggedUpdateMaintenance {
 				);
 				foreach ( $rows as $row ) {
 					$this->handleRow( $row );
+					$lastPage = $row->page_id;
 				}
 			} while ( $rows->numRows() >= $this->getBatchSize() );
 		}


### PR DESCRIPTION
FixDefaultJsonContentPages iterates in batches over all pages ending with 'json' in
NS_MEDIAWIKI and NS_USER namespaces. Because $lastPage was never updated, the loop
was stuck processing the first batch. This was affecting the upgrade process for wikis
having more than a single batch (100 items) of pages ending with '.json' in a namespace.

Change-Id: I6953bf4c071d8635383b3be067ff3aedddaf8130

Dont't merge, close PR after CR!