### PR TITLE
ExtensionRegistry: Use a global cache key for the queue

### DIFF
--- a/includes/registration/ExtensionRegistry.php
+++ b/includes/registration/ExtensionRegistry.php
@@ -161,7 +161,9 @@ class ExtensionRegistry {
 			$cache = new EmptyBagOStuff();
 		}
 		// See if this queue is in APC
-		$key = $cache->makeKey(
+		// Fandom change: Use makeGlobalKey() to allow sharing the cache
+		// between wikis using the same set of extensions
+		$key = $cache->makeGlobalKey(
 			'registration',
 			md5( json_encode( $this->queued + $versions ) )
 		);


### PR DESCRIPTION
Use a global APCu cache key for the ExtensionRegistry queue to allow reusing the
cache between wikis that use the same set of extensions, instead of having
separate cache keys per wiki. The cache key already varies on the hash of the
list of extensions enqueued for loading.