### PR TITLE
PLATFORM-5269 | Add UserLoadFromCache Hook to User::loadFromCache

### DIFF
--- a/includes/user/User.php
+++ b/includes/user/User.php
@@ -521,6 +521,22 @@ class User implements IDBAccessObject, UserIdentity {
 	 */
 	protected function loadFromCache() {
 		$cache = MediaWikiServices::getInstance()->getMainWANObjectCache();
+
+		/**
+		 * Fandom change - start (@author ttomalak)
+		 *
+		 * Allow to modify cache options, for example to add additional check keys
+		 * which will allow to invalidate cache on replication.
+		 *
+		 * PLATFORM-5269
+		 */
+		$cacheOpts = [ 'pcTTL' => $cache::TTL_PROC_LONG, 'version' => self::VERSION ];
+
+
+		Hooks::run( 'UserLoadFromCache', [ $this, &$cacheOpts ] );
+		/** Fandom change - end */
+
+
 		$data = $cache->getWithSetCallback(
 			$this->getCacheKey( $cache ),
 			$cache::TTL_HOUR,
@@ -552,7 +568,7 @@ class User implements IDBAccessObject, UserIdentity {
 
 				return $data;
 			},
-			[ 'pcTTL' => $cache::TTL_PROC_LONG, 'version' => self::VERSION ]
+			$cacheOpts // Fandom change PLATFORM-5269
 		);
 
 		// Restore from cache


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/PLATFORM-5269

## Description
Hooks allows to modify cache options, before user is loaded. This can be used to pass additional `checkKeys`, which will refresh user if those changed.

## Who might be interested?
@Wikia/core-platform-team 