### PR TITLE
MessageCache: Let extensions signal that a particular key cannot exist in DB

### DIFF
--- a/includes/cache/MessageCache.php
+++ b/includes/cache/MessageCache.php
@@ -887,7 +887,11 @@ class MessageCache {
 		// Normalise title-case input (with some inlining)
 		$lckey = self::normalizeKey( $key );
 
-		Hooks::run( 'MessageCache::get', [ &$lckey ] );
+		// Fandom change: Workaround T193271 performance regression by letting extensions signal
+		// that a particular message key cannot exist in the database
+		if ( !Hooks::run( 'MessageCache::get', [ &$lckey ] ) ) {
+			return false;
+		}
 
 		// Loop through each language in the fallback list until we find something useful
 		$message = $this->getMessageFromFallbackChain(


### PR DESCRIPTION
Workaround T193271 performance regression by letting extensions signal that a
particular message key cannot exist in the DB. This allows us to use a
MessageCache::get hook handler to dynamically handle problematic keys in one
place (MessageCachePerformance extension) without patching core, while
maintaining compatibility with conditional message lookups that trigger fallback
logic depending on the outcome of a Message::exists() existence check.