### PR TITLE
Remove obsolete actor sync hook

### DIFF
--- a/includes/user/User.php
+++ b/includes/user/User.php
@@ -2574,23 +2574,8 @@ class User implements IDBAccessObject, UserIdentity {
 				$this->invalidateCache();
 			} else {
 				list( $index, $options ) = DBAccessObjectUtils::getDBOptions( $this->queryFlagsUsed );
-				/**
-				 * Fandom change
-				 * Extra hook to investigate in which scenarios this can happen and if we should try
-				 * lazy-loading the actor from the shared cluster and storing it locally.
-				 *
-				 * PLATFORM-5898
-				 */
-				if ( Hooks::run( 'UserBeforeLazyLoadCreateActor', [
-					&$this->mActorId,
-					$index,
-					$options,
-					$q['actor_user'],
-					$q['actor_name']
-				] ) ) {
-					$db = wfGetDB( $index );
-					$this->mActorId = (int)$db->selectField( 'actor', 'actor_id', $q, __METHOD__, $options );
-				}
+				$db = wfGetDB( $index );
+				$this->mActorId = (int)$db->selectField( 'actor', 'actor_id', $q, __METHOD__, $options );
 			}
 			$this->setItemLoaded( 'actor' );
 		}


### PR DESCRIPTION
Hitting the shared cluster in this hook can cause some overload, as we're not expected to create actors in this part of the code. which means we could be querying for the same actor all over again.
I think the default MediaWiki behaviour (just checking the local cluster copy) is fine here.