### PR TITLE
Gallery slideshow: Fix height calculation

### DIFF
--- a/resources/src/mediawiki.page.gallery.slideshow.js
+++ b/resources/src/mediawiki.page.gallery.slideshow.js
@@ -19,9 +19,6 @@
 		this.$galleryBox = this.$gallery.find( '.gallerybox' );
 		this.$currentImage = null;
 		this.imageInfoCache = {};
-		if ( this.$gallery.parent().attr( 'id' ) !== 'mw-content-text' ) {
-			this.$container = this.$gallery.parent();
-		}
 
 		// Initialize
 		this.drawCarousel();
@@ -85,11 +82,6 @@
 
 	/**
 	 * @property {jQuery} $currentImage The `<li>` element of the current image.
-	 */
-
-	/**
-	 * @property {jQuery} $container If the gallery contained in an element that is
-	 *   not the main content element, then it stores that element.
 	 */
 
 	/**
@@ -185,15 +177,8 @@
 	 * size.
 	 */
 	mw.GallerySlideshow.prototype.setSizeRequirement = function () {
-		var w, h;
-
-		if ( this.$container !== undefined ) {
-			w = this.$container.width() * 0.9;
-			h = ( this.$container.height() - this.getChromeHeight() ) * 0.9;
-		} else {
-			w = this.$imgContainer.width();
+		var w = this.$imgContainer.width(),
 			h = Math.min( $( window ).height() * ( 3 / 4 ), this.$imgContainer.width() ) - this.getChromeHeight();
-		}
 
 		// Only update and flush the cache if the size changed
 		if ( w !== this.imageWidth || h !== this.imageHeight ) {
@@ -211,7 +196,7 @@
 	 * @return {number} Height
 	 */
 	mw.GallerySlideshow.prototype.getChromeHeight = function () {
-		return this.$interface.outerHeight() + this.$galleryCaption.outerHeight();
+		return this.$interface.outerHeight() + ( this.$galleryCaption.outerHeight() || 0 );
 	};
 
 	/**


### PR DESCRIPTION
Remove $container check. This check was broken due to
recent changes in skin output (adding mw-parser-output),
and was not necessary, as the computation without it is
based on $imgContainer, which is also bound by a container.

This avoids the height being set to "NaNpx", or the full
height of the page.

Bug: T196723
Change-Id: I9b4fda9c71502bf749271c55a6945d9f4a4f913e