### PR TITLE
WikiPage: Add process cache for content model

### DIFF
--- a/includes/page/WikiPage.php
+++ b/includes/page/WikiPage.php
@@ -663,7 +663,8 @@ class WikiPage implements Page, IDBAccessObject {
 						wfWarn( "Page $title exists but has no (visible) revisions!" );
 						return $this->mTitle->getContentModel();
 					}
-				}
+				},
+				[ 'pcTTL' => $cache::TTL_PROC_LONG ]
 			);
 		}
 

--- a/tests/phpunit/includes/page/ArticleViewTest.php
+++ b/tests/phpunit/includes/page/ArticleViewTest.php
@@ -50,6 +50,9 @@ class ArticleViewTest extends MediaWikiTestCase {
 			$revisions[ $key ] = $rev;
 		}
 
+		// Clear content model cache to support tests that mock the revision
+		$this->getServiceContainer()->getMainWANObjectCache()->clearProcessCache();
+
 		return $page;
 	}
 


### PR DESCRIPTION
WikiPage::getContentModel() gets called several times per request via
Action::getActionName(), triggering memcached I/O on each call - making it the single most requested key class at 15K rq/s. Excimer icicle graphs for index.php indicate about ~1% of time is spent in this method, so
let's add process caching to avoid redundant memcached fetches on subsequent
invocations.

Change-Id: Icdb9ffb849a0a0a264083957431495f8f4fb783e