### PR TITLE
Reduce contention of getScopedLockAndFlush() callers by using the DB domain in the key

### DIFF
--- a/includes/deferred/LinksUpdate.php
+++ b/includes/deferred/LinksUpdate.php
@@ -212,7 +212,7 @@ class LinksUpdate extends DataUpdate implements EnqueueableDataUpdate {
 	 * @since 1.27
 	 */
 	public static function acquirePageLock( IDatabase $dbw, $pageId, $why = 'atomicity' ) {
-		$key = "LinksUpdate:$why:pageid:$pageId";
+		$key = "{$dbw->getDomainID()}:LinksUpdate:$why:pageid:$pageId"; // per-wiki
 		$scopedLock = $dbw->getScopedLockAndFlush( $key, __METHOD__, 15 );
 		if ( !$scopedLock ) {
 			$logger = LoggerFactory::getInstance( 'SecondaryDataUpdate' );

--- a/includes/jobqueue/jobs/CategoryMembershipChangeJob.php
+++ b/includes/jobqueue/jobs/CategoryMembershipChangeJob.php
@@ -99,7 +99,7 @@ class CategoryMembershipChangeJob extends Job {
 		}
 
 		// Use a named lock so that jobs for this page see each others' changes
-		$lockKey = "CategoryMembershipUpdates:{$page->getId()}";
+		$lockKey = "{$dbw->getDomainID()}:CategoryMembershipChange:{$page->getId()}"; // per-wiki
 		$scopedLock = $dbw->getScopedLockAndFlush( $lockKey, __METHOD__, 3 );
 		if ( !$scopedLock ) {
 			$this->setLastError( "Could not acquire lock '$lockKey'" );

--- a/includes/jobqueue/jobs/ClearUserWatchlistJob.php
+++ b/includes/jobqueue/jobs/ClearUserWatchlistJob.php
@@ -58,7 +58,7 @@ class ClearUserWatchlistJob extends Job {
 		}
 
 		// Use a named lock so that jobs for this user see each others' changes
-		$lockKey = "ClearUserWatchlistJob:$userId";
+		$lockKey = "{{$dbw->getDomainID()}}:ClearUserWatchlist:$userId"; // per-wiki
 		$scopedLock = $dbw->getScopedLockAndFlush( $lockKey, __METHOD__, 10 );
 		if ( !$scopedLock ) {
 			$this->setLastError( "Could not acquire lock '$lockKey'" );

--- a/includes/user/UserGroupMembership.php
+++ b/includes/user/UserGroupMembership.php
@@ -250,7 +250,7 @@ class UserGroupMembership {
 		$ticket = $lbFactory->getEmptyTransactionTicket( __METHOD__ );
 		$dbw = $services->getDBLoadBalancer()->getConnection( DB_MASTER );
 
-		$lockKey = $dbw->getDomainID() . ':usergroups-prune'; // specific to this wiki
+		$lockKey = "{$dbw->getDomainID()}:UserGroupMembership:purge"; // per-wiki
 		$scopedLock = $dbw->getScopedLockAndFlush( $lockKey, __METHOD__, 0 );
 		if ( !$scopedLock ) {
 			return false; // already running


### PR DESCRIPTION
https://fandom.atlassian.net/browse/SITE-945
https://github.com/wikimedia/mediawiki/commit/d4cb1968c844fcd4e29e6ba40751f6639dca0e53
https://kibana.wikia-inc.com/goto/8e18151becbb58c4523ebb8526dda7a1

Per conversation with @mszabo-wikia, let's check if the issue described in the ticket is a result of the simultaneous edits from pages with the same page_id from different wikis. If not, we'll at least get rid of some deadlocks

@Wikia/site-experience 
@Wikia/core-platform-team 
