### PR TITLE
PLATFORM-6360 Backport T725053 fix to ReplaceText

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,8 +68,8 @@
 	branch = REL1_33
 [submodule "ReplaceText"]
 	path = extensions/ReplaceText
-	url = https://gerrit.wikimedia.org/r/mediawiki/extensions/ReplaceText
-	branch = REL1_33
+	url = https://github.com/Wikia/mediawiki-extensions-ReplaceText
+	branch = REL1_33_FANDOM
 [submodule "SpamBlacklist"]
 	path = extensions/SpamBlacklist
 	url = https://gerrit.wikimedia.org/r/mediawiki/extensions/SpamBlacklist


### PR DESCRIPTION
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/ReplaceText/+/725053
https://fandom.atlassian.net/browse/PLATFORM-6360

This ports a security fix to ReplaceText from 1.31 onto 1.33. This fix is included from 1.35 onwards, so the fork can be discarded afterward.