### PR TITLE
Apply our 1.33 customizations onto 1.37

### DIFF
--- a/includes/cache/MessageCache.php
+++ b/includes/cache/MessageCache.php
@@ -947,7 +947,11 @@ class MessageCache implements LoggerAwareInterface {
 		// Normalise title-case input (with some inlining)
 		$lckey = self::normalizeKey( $key );
 
-		$this->hookRunner->onMessageCache__get( $lckey );
+		// Fandom change: Workaround T193271 performance regression by letting extensions signal
+		// that a particular message key cannot exist in the database
+		if ( !$this->hookRunner->onMessageCache__get( $lckey ) ) {
+			return false;
+		}
 
 		// Loop through each language in the fallback list until we find something useful
 		$message = $this->getMessageFromFallbackChain(

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -2385,17 +2385,23 @@ class Parser {
 			$imagematch = false;
 		}
 
+		// Fandom change - start (@author ttomalak)
+		// allow fandom image links PLATFORM-4871
+		$allowed = $this->getHookContainer()->run( 'ParserAllowExternalImage', [ $url ] );
+
 		if ( $this->mOptions->getAllowExternalImages()
-			|| ( $imagesexception && $imagematch )
+			 || $allowed
+			 || ( $imagesexception && $imagematch )
 		) {
-			if ( preg_match( self::EXT_IMAGE_REGEX, $url ) ) {
+			if ( preg_match( self::EXT_IMAGE_REGEX, $url ) || $allowed ) {
 				# Image found
 				$text = Linker::makeExternalImage( $url );
 			}
 		}
 		if ( !$text && $this->mOptions->getEnableImageWhitelist()
-			&& preg_match( self::EXT_IMAGE_REGEX, $url )
+			 && ( preg_match( self::EXT_IMAGE_REGEX, $url ) || $allowed )
 		) {
+			// Fandom change - end
 			$whitelist = explode(
 				"\n",
 				wfMessage( 'external_image_whitelist' )->inContentLanguage()->text()

--- a/includes/parser/Sanitizer.php
+++ b/includes/parser/Sanitizer.php
@@ -631,13 +631,15 @@ class Sanitizer {
 	 * @return string
 	 */
 	public static function checkCss( $value ) {
+		global $wgEnableHydraFeatures;
 		$value = self::normalizeCss( $value );
 
 		// Reject problematic keywords and control characters
 		if ( preg_match( '/[\000-\010\013\016-\037\177]/', $value ) ||
 			strpos( $value, UtfNormal\Constants::UTF8_REPLACEMENT ) !== false ) {
 			return '/* invalid control char */';
-		} elseif ( preg_match(
+		/** Fandom change begin -- we need to remove "| var\s*\(" on GP wikis **/
+		} elseif ( empty( $wgEnableHydraFeatures ) && preg_match(
 			'! expression
 				| filter\s*:
 				| accelerator\s*:
@@ -651,7 +653,21 @@ class Sanitizer {
 				| var\s*\(
 			!ix', $value ) ) {
 			return '/* insecure input */';
+		} elseif ( !empty( $wgEnableHydraFeatures ) && preg_match(
+			'! expression
+				| filter\s*:
+				| accelerator\s*:
+				| -o-link\s*:
+				| -o-link-source\s*:
+				| -o-replace\s*:
+				| url\s*\(
+				| image\s*\(
+				| image-set\s*\(
+				| attr\s*\([^)]+[\s,]+url
+			!ix', $value ) ) {
+			return '/* insecure input */';
 		}
+		/** Fandom change end **/
 		return $value;
 	}
 

--- a/includes/user/User.php
+++ b/includes/user/User.php
@@ -531,6 +531,21 @@ class User implements Authority, UserIdentity, UserEmailContact {
 		global $wgFullyInitialised;
 
 		$cache = MediaWikiServices::getInstance()->getMainWANObjectCache();
+
+		/**
+		 * Fandom change - start (@author ttomalak)
+		 *
+		 * Allow to modify cache options, for example to add additional check keys
+		 * which will allow to invalidate cache on replication.
+		 *
+		 * PLATFORM-5269
+		 */
+		$cacheOpts = [ 'pcTTL' => $cache::TTL_PROC_LONG, 'version' => self::VERSION ];
+
+		$this->getHookContainer()->run( 'UserLoadFromCache', [ $this, &$cacheOpts ] );
+		/** Fandom change - end */
+
+
 		$data = $cache->getWithSetCallback(
 			$this->getCacheKey( $cache ),
 			$cache::TTL_HOUR,
@@ -568,7 +583,7 @@ class User implements Authority, UserIdentity, UserEmailContact {
 
 				return $data;
 			},
-			[ 'pcTTL' => $cache::TTL_PROC_LONG, 'version' => self::VERSION ]
+			$cacheOpts // Fandom change PLATFORM-5269
 		);
 
 		// Restore from cache


### PR DESCRIPTION
We've made various backports and customizations to MW 1.33, some of which are still relevant in 1.37. This patch starts off a fresh clone of upstream's REL1_37 branch (REL1_37-Fandom), and cherry-picks select changes on top of it:
* https://github.com/Wikia/mediawiki/pull/19
* f900f0d28a353a049f3dda6386dad4b769be8c5d
* d2a8252524ed8f162aa604b6ea117a42cfd838c2
* e7282d7b882c6873597be73b12545e7872a1b829

Notably, we have some patches that I have not applied yet, because I feel we should have a conversation about them first—they might not be relevant any more. Specifically:
* https://github.com/Wikia/mediawiki/pull/9 - this technically works, but RC is unusably slow at such volume. I'd recommend reconsidering.
* https://github.com/Wikia/mediawiki/pull/18, https://github.com/Wikia/mediawiki/pull/23, https://github.com/Wikia/mediawiki/pull/24 seem to be fixing bugs in the import/export process caused by our custom way of storing user names prior to actor migration. I'd expect this to have been fixed by actor migration, so perhaps not needed any more?
* https://github.com/Wikia/mediawiki/pull/29 is likely still relevant, but we should first discuss whether we should instead use an ActorStore service override or a different approach.
* https://github.com/Wikia/mediawiki/pull/28 is an incomplete/incorrect fix for [T138031](https://phabricator.wikimedia.org/T138031). If this is a problem for our users, then we should fix the upstream bug.