### PR TITLE
Don't p-wrap <aside> tags in extension HTML

### DIFF
--- a/includes/parser/BlockLevelPass.php
+++ b/includes/parser/BlockLevelPass.php
@@ -325,7 +325,7 @@ class BlockLevelPass {
 					'/<('
 						. "\\/({$blockElems})|({$antiBlockElems})|"
 						// Never suppresses
-						. '\\/?(center|blockquote|div|hr|mw:)'
+						. '\\/?(center|blockquote|div|hr|mw:|aside)'
 						. ')\\b/iS',
 					$t
 				);

--- a/includes/parser/Sanitizer.php
+++ b/includes/parser/Sanitizer.php
@@ -1991,6 +1991,9 @@ class Sanitizer {
 			// So we don't bother including $common attributes that have no purpose.
 			'meta' => [ 'itemprop', 'content' ],
 			'link' => [ 'itemprop', 'href', 'title' ],
+
+			# HTML 5 section 4.3.5
+			'aside' => $common,
 		];
 
 		return $whitelist;

--- a/tests/parser/ParserTestParserHook.php
+++ b/tests/parser/ParserTestParserHook.php
@@ -31,6 +31,7 @@ class ParserTestParserHook {
 		$parser->setHook( 'tag', [ __CLASS__, 'dumpHook' ] );
 		$parser->setHook( 'tåg', [ __CLASS__, 'dumpHook' ] );
 		$parser->setHook( 'statictag', [ __CLASS__, 'staticTagHook' ] );
+		$parser->setHook( 'asidetag', [ __CLASS__, 'asideTagHook' ] );
 		return true;
 	}
 
@@ -58,5 +59,9 @@ class ParserTestParserHook {
 				"text: " . var_export( $in, true ) . "\n" .
 				"argv: " . var_export( $argv, true ) . "\n";
 		}
+	}
+
+	public static function asideTagHook(): string {
+		return Html::element( 'aside', [], 'Some aside content' );
 	}
 }


### PR DESCRIPTION
Our PortableInfobox extension uses the HTML5 <aside> tag in its generated HTML.
This tag isn't recognized as a block element (in the way e.g. <div> is) by the
legacy parser, resulting in some spurious empty paragraphs in the output.

As a fix, make the legacy parser aware of <aside> tags to avoid unnecessary
p-wrapping. Also add <aside> to the Sanitizer's internal attribute check.
I3e57f55ac69d2c1ee8a1d41c21b692e56fc7e628 takes care of updating Parsoid-PHP
accordingly.

Bug: T278565
Change-Id: I89dbdf7770e13e1b62320228a366c64e64217b0b