### PR TITLE
PLATFORM-6677 | Fix revision_actor_temp locking on new revision creation

### DIFF
--- a/includes/ActorMigration.php
+++ b/includes/ActorMigration.php
@@ -266,13 +266,21 @@ class ActorMigration {
 						}
 						$set[$to] = $extra[$from];
 					}
-					$dbw->upsert(
+					/**
+					 * Fandom change - start (@author ttomalak)
+					 * Upsert can very often cause deadlock during multiple inserts at the same
+					 * time as it locks whole table. Instead it should be safe make this as and
+					 * insert as all of the records created by this callback should be
+					 * auto-incremented.
+					 *
+					 * PLATFORM-5707
+					 */
+					$dbw->insert(
 						$t['table'],
 						[ $t['pk'] => $pk ] + $set,
-						[ $t['pk'] ],
-						$set,
 						$func
 					);
+					/** Fandom change - end */
 				};
 			} else {
 				$ret[$actor] = $id;


### PR DESCRIPTION
### Links
* https://fandom.atlassian.net/browse/PLATFORM-6677

### Description
If multiple inserts happen at the same time, there are situations where upserting to new revision_actor_temp can cause deadlock. ActorMigration::getInsertValuesWithTempTable `pk` values are always autoincremented and there should not be cases where upsert is needed.

In one place where the function is used RevisionStore::insertRevisionRowOn, there is a similar function for comment on which insert is used as well.

### Who might be interested?
@Wikia/platform-team @mszabo-wikia 