### PR TITLE
Backport fix for T285984 for graceful error handling in REST routes

### DIFF
--- a/includes/Rest/EntryPoint.php
+++ b/includes/Rest/EntryPoint.php
@@ -9,6 +9,7 @@ use MediaWiki\Config\ServiceOptions;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\BasicAccess\CompoundAuthorizer;
 use MediaWiki\Rest\BasicAccess\MWBasicAuthorizer;
+use MediaWiki\Rest\Reporter\MWErrorReporter;
 use MediaWiki\Rest\Validator\Validator;
 use RequestContext;
 use Title;
@@ -75,6 +76,7 @@ class EntryPoint {
 			$authority,
 			$objectFactory,
 			$restValidator,
+			new MWErrorReporter(),
 			$services->getHookContainer()
 		) )->setCors( $cors );
 	}

--- a/includes/Rest/Reporter/ErrorReporter.php
+++ b/includes/Rest/Reporter/ErrorReporter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MediaWiki\Rest\Reporter;
+
+use MediaWiki\Rest\Handler;
+use MediaWiki\Rest\RequestInterface;
+use Throwable;
+
+/**
+ * An ErrorReporter internally reports an error that happened during the handling of a request.
+ * It must have no effect on the response sent to the client.
+ *
+ * @since 1.38
+ */
+interface ErrorReporter {
+
+	/**
+	 * @param Throwable $error
+	 * @param Handler $handler
+	 * @param RequestInterface $request
+	 */
+	public function reportError( Throwable $error, Handler $handler, RequestInterface $request );
+
+}

--- a/includes/Rest/Reporter/MWErrorReporter.php
+++ b/includes/Rest/Reporter/MWErrorReporter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MediaWiki\Rest\Reporter;
+
+use MediaWiki\Rest\Handler;
+use MediaWiki\Rest\RequestInterface;
+use MWExceptionHandler;
+use Throwable;
+
+/**
+ * Error reporter based on MWExceptionHandler.
+ * @see MWExceptionHandler
+ * @since 1.38
+ */
+class MWErrorReporter implements ErrorReporter {
+
+	/**
+	 * @param Throwable $error
+	 * @param Handler $handler
+	 * @param RequestInterface $request
+	 */
+	public function reportError( Throwable $error, Handler $handler, RequestInterface $request ) {
+		MWExceptionHandler::rollbackPrimaryChangesAndLog(
+			$error,
+			MWExceptionHandler::CAUGHT_BY_ENTRYPOINT
+		);
+	}
+
+}

--- a/includes/Rest/Reporter/PHPErrorReporter.php
+++ b/includes/Rest/Reporter/PHPErrorReporter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace MediaWiki\Rest\Reporter;
+
+use MediaWiki\Rest\Handler;
+use MediaWiki\Rest\RequestInterface;
+use Throwable;
+
+/**
+ * Error reporter based on php's native trigger_error() method.
+ * @since 1.38
+ */
+class PHPErrorReporter implements ErrorReporter {
+
+	/** @var int */
+	private $level;
+
+	/**
+	 * @param int $level The error level to pass to trigger_error
+	 */
+	public function __construct( $level = E_USER_WARNING ) {
+		$this->level = $level;
+	}
+
+	/**
+	 * @param Throwable $error
+	 * @param Handler $handler
+	 * @param RequestInterface $request
+	 */
+	public function reportError( Throwable $error, Handler $handler, RequestInterface $request ) {
+		$firstLine = preg_split( '#$#m', (string)$error, 0 )[0];
+		trigger_error( $firstLine, $this->level );
+	}
+
+}

--- a/includes/Rest/ResponseFactory.php
+++ b/includes/Rest/ResponseFactory.php
@@ -231,11 +231,12 @@ class ResponseFactory {
 			}
 		} else {
 			$response = $this->createHttpError( 500, [
-				'message' => 'Error: exception of type ' . get_class( $exception ),
+				'message' => 'Error: exception of type ' . get_class( $exception ) . ': '
+					. $exception->getMessage(),
 				'exception' => MWExceptionHandler::getStructuredExceptionData( $exception )
 			] );
-			// FIXME should we try to do something useful with ILocalizedException?
-			// FIXME should we try to do something useful with common MediaWiki errors like ReadOnlyError?
+			// XXX: should we try to do something useful with ILocalizedException?
+			// XXX: should we try to do something useful with common MediaWiki errors like ReadOnlyError?
 		}
 		return $response;
 	}

--- a/tests/phpunit/includes/Rest/EntryPointTest.php
+++ b/tests/phpunit/includes/Rest/EntryPointTest.php
@@ -10,6 +10,7 @@ use MediaWiki\Rest\BasicAccess\StaticBasicAuthorizer;
 use MediaWiki\Rest\CorsUtils;
 use MediaWiki\Rest\EntryPoint;
 use MediaWiki\Rest\Handler;
+use MediaWiki\Rest\Reporter\PHPErrorReporter;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\RequestInterface;
 use MediaWiki\Rest\ResponseFactory;
@@ -47,6 +48,7 @@ class EntryPointTest extends \MediaWikiIntegrationTestCase {
 			$authority,
 			$objectFactory,
 			new Validator( $objectFactory, $request, $authority ),
+			new PHPErrorReporter(),
 			$this->createHookContainer()
 		);
 	}

--- a/tests/phpunit/unit/includes/Rest/BasicAccess/MWBasicRequestAuthorizerTest.php
+++ b/tests/phpunit/unit/includes/Rest/BasicAccess/MWBasicRequestAuthorizerTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use MediaWiki\Permissions\SimpleAuthority;
 use MediaWiki\Rest\BasicAccess\MWBasicAuthorizer;
 use MediaWiki\Rest\Handler;
+use MediaWiki\Rest\Reporter\PHPErrorReporter;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\ResponseFactory;
 use MediaWiki\Rest\Router;
@@ -41,6 +42,7 @@ class MWBasicRequestAuthorizerTest extends MediaWikiUnitTestCase {
 			$authority,
 			$objectFactory,
 			new Validator( $objectFactory, $request, $authority ),
+			new PHPErrorReporter(),
 			$this->createHookContainer()
 		);
 	}

--- a/tests/phpunit/unit/includes/Rest/ResponseFactoryTest.php
+++ b/tests/phpunit/unit/includes/Rest/ResponseFactoryTest.php
@@ -162,7 +162,7 @@ class ResponseFactoryTest extends MediaWikiUnitTestCase {
 		$body->rewind();
 		$data = json_decode( $body->getContents(), true );
 		$this->assertSame( 500, $data['httpCode'] );
-		$this->assertSame( 'Error: exception of type Exception', $data['message'] );
+		$this->assertSame( 'Error: exception of type Exception: hello', $data['message'] );
 	}
 
 	public function testCreateFromExceptionWrapped() {

--- a/tests/phpunit/unit/includes/Rest/testRoutes.json
+++ b/tests/phpunit/unit/includes/Rest/testRoutes.json
@@ -16,6 +16,10 @@
 		"factory": "MediaWiki\\Tests\\Rest\\RouterTest::throwHandlerFactory"
 	},
 	{
+		"path": "/mock/RouterTest/fatal",
+		"factory": "MediaWiki\\Tests\\Rest\\RouterTest::fatalHandlerFactory"
+	},
+	{
 		"path": "/mock/RouterTest/throwRedirect",
 		"factory": "MediaWiki\\Tests\\Rest\\RouterTest::throwRedirectHandlerFactory"
 	},


### PR DESCRIPTION
MW's REST API, as of the 1.37 release, will gracefully convert `HttpException`s to error responses but will let any other exception bubble up to MW's standard error handler that will then render a fully fledged and skinned HTML error page—something not really expected in an API context. Given that some of the handlers we're going to be shipping in 1.37 can and will throw such exceptions (e.g. Parsoid's routes will throw `ValidationException`s on invalid user-supplied parameters), let's be prudent and backport some proper error handling here.