### PR TITLE
PLATFORM-6588 SECURITY: Fix permissions checks in undo actions

### DIFF
--- a/includes/EditPage.php
+++ b/includes/EditPage.php
@@ -1288,8 +1288,10 @@ class EditPage implements IEditObject {
 			$undo = $request->getInt( 'undo' );
 
 			if ( $undo > 0 && $undoafter > 0 ) {
-				$undorev = $this->revisionStore->getRevisionById( $undo );
-				$oldrev = $this->revisionStore->getRevisionById( $undoafter );
+				// The use of getRevisionByTitle() is intentional, as allowing access to
+				// arbitrary revisions on arbitrary pages bypass partial visibility restrictions (T297322).
+				$undorev = $this->revisionStore->getRevisionByTitle( $this->mTitle, $undo );
+				$oldrev = $this->revisionStore->getRevisionByTitle( $this->mTitle, $undoafter );
 				$undoMsg = null;
 
 				# Sanity check, make sure it's the right page,


### PR DESCRIPTION
https://fandom.atlassian.net/browse/PLATFORM-6588


Both traditional action=edit&undo= and the newer
action=mcrundo/action=mcrrestore endpoints suffer from a flaw that
allows for leaking entire private wikis by enumerating through revision
IDs when at least one page was publicly accessible via $wgWhitelistRead.
This is CVE-2021-44858.

05f06286f4def removed the restriction that user-supplied undo IDs belong
ot the same page, and was then copied into mcrundo. This check has been
restored by using RevisionLookup::getRevisionByTitle(), which returns
null if the revid is on a different page. This will break the workflow
outlined in T58184, but that could be restored in the future with better
access control checks.

action=mcrundo/action=restore suffer from an additional flaw that allows
for bypassing most editing restrictions. It makes no check on whether
user has the 'edit' permission or can even edit that page (page
protection, etc.). This is CVE-2021-44857.

This has been fixed by requiring the 'edit' permission to even invoke
the action (via Action::getRestriction()), as well as checking the
user's permissions to edit the specific page before saving.

The EditFilterMergedContent hook is also run against the revision before
it's saved so SpamBlacklist, AbuseFilter, etc. have a chance to review
the new page contents before saving.

Kudos to Dylsss for the identification and report.

Bug: T297322
Co-authored-by: Taavi Väänänen <hi@taavi.wtf>
Change-Id: I496093adfcf5a0e30774d452b650b751518370ce