### PR TITLE
Language: Don't generate local dates in the year 10000

### DIFF
--- a/includes/language/Language.php
+++ b/includes/language/Language.php
@@ -2119,6 +2119,13 @@ class Language {
 				$userTZ = new DateTimeZone( $data[2] );
 				$date = new DateTime( $ts, new DateTimeZone( 'UTC' ) );
 				$date->setTimezone( $userTZ );
+
+				// Don't generate a timestamp that's too large for sprintfDate() to handle,
+				// see T32148.
+				if ( $date->format( 'Y' ) >= '10000' ) {
+					return $ts;
+				}
+
 				return $date->format( 'YmdHis' );
 			} catch ( Exception $e ) {
 				// Unrecognized timezone, default to 'Offset' with the stored offset.
@@ -2161,6 +2168,13 @@ class Language {
 			(int)substr( $ts, 4, 2 ), # Month
 			(int)substr( $ts, 6, 2 ), # Day
 			(int)substr( $ts, 0, 4 ) ); # Year
+
+		// Don't generate a timestamp that's too large for sprintfDate() to handle,
+		// see T32148.
+		if ( date( 'Y', $t ) >= '10000' ) {
+			Wikimedia\restoreWarnings();
+			return $ts;
+		}
 
 		$date = date( 'YmdHis', $t );
 		Wikimedia\restoreWarnings();


### PR DESCRIPTION
MediaWiki only supports 14 character timestamps, and most date input
fields accordingly limit the accepted input range to fit within that
constraint, so the largest acceptable date is 9999-12-31 23:59:59.
However, if an user's own timezone preference is set to a timezone with
a higher offset than the server timezone, such dates may overflow into
the year 10000 and cause an error ("The timestamp XYZ should have 14
characters"). This very commonly happens when an admin decides to block
an user until 9999-12-31 instead of using the infinite expiry for some
reason, effectively breaking the block log for every user with a
timezone offset higher than the server offset.

Making MediaWiki support dates beyond the year 10000 would be a larger
undertaking, so for now, limit the impact of this problem by ensuring
that userAdjust() does not generate a local date that sprintfDate()
would not be able to handle.