### PR TITLE
MediaWiki: Avoid spurious page query

### DIFF
--- a/includes/MediaWiki.php
+++ b/includes/MediaWiki.php
@@ -430,10 +430,9 @@ class MediaWiki {
 		$article = Article::newFromWikiPage( $page, $this->context );
 
 		// Skip some unnecessary code if the content model doesn't support redirects
-		if ( !$services->getContentHandlerFactory()
-				->getContentHandler( $title->getContentModel() )
-				->supportsRedirects()
-		) {
+		// Use the page content model rather than invoking Title::getContentModel()
+		// to avoid querying page data twice (T206498)
+		if ( !$page->getContentHandler()->supportsRedirects() ) {
 			return $article;
 		}
 


### PR DESCRIPTION
initializeArticle() calls Title::getContentModel() before the WikiPage
object for the current page has been initialized, which results in a
redundant query to the page table as WikiPage hasn't yet seeded
LinkCache with data for the current page. Instead, use
WikiPage::getContentHandler(), which simply triggers WikiPage
initialization a bit earlier and eliminates the redundant query.

Bug: T206498
Change-Id: I2bd8000b9b67a54ad194fa6aca86be3c6039c8be