### PR TITLE
SITE-2630: Ignore pages that can't exist on Special:ListRedirects

### DIFF
--- a/includes/specials/SpecialListRedirects.php
+++ b/includes/specials/SpecialListRedirects.php
@@ -130,6 +130,9 @@ class SpecialListRedirects extends QueryPage {
 			);
 		} else {
 			$title = Title::makeTitle( $row->namespace, $row->title );
+			if ( !$title->canExist() ) {
+				return null;
+			}
 			$page = $this->wikiPageFactory->newFromTitle( $title );
 
 			return $page->getRedirectTarget();


### PR DESCRIPTION
Backport patch for https://phabricator.wikimedia.org/T279840.