### PR TITLE
ApiQueryRevisionsBase: Fix non-numeric diffto param handling on PHP 8

### DIFF
--- a/includes/api/ApiQueryRevisionsBase.php
+++ b/includes/api/ApiQueryRevisionsBase.php
@@ -194,7 +194,7 @@ abstract class ApiQueryRevisionsBase extends ApiQueryGeneratorBase {
 			// Check whether the revision exists and is readable,
 			// DifferenceEngine returns a rather ambiguous empty
 			// string if that's not the case
-			if ( $params['diffto'] != 0 ) {
+			if ( is_numeric( $params['diffto'] ) && $params['diffto'] != 0 ) {
 				$difftoRev = $this->revisionStore->getRevisionById( $params['diffto'] );
 				if ( !$difftoRev ) {
 					$this->dieWithError( [ 'apierror-nosuchrevid', $params['diffto'] ] );


### PR DESCRIPTION
Given $params = [ 'diffto' => 'prev' ];, $params['diffto'] != 0 is true on PHP 8 and false on PHP 7.3.[1] Fix the logic to also check whether diffto is numeric before treating it as a revision ID.

---
[1] https://onlinephp.io/c/81e7b