### PR TITLE
WikiExporter: Avoid bitwise op with non-integer

### DIFF
--- a/includes/export/WikiExporter.php
+++ b/includes/export/WikiExporter.php
@@ -301,7 +301,7 @@ class WikiExporter {
 	 * @throws Exception
 	 */
 	protected function dumpFrom( $cond = '', $orderRevs = false ) {
-		if ( $this->history & self::LOGS ) {
+		if ( is_int( $this->history ) && ( $this->history & self::LOGS ) ) {
 			$this->dumpLogs( $cond );
 		} else {
 			$this->dumpPages( $cond, $orderRevs );


### PR DESCRIPTION
Before PHP8, the operation evaluates to zero; from PHP8, TypeError is raised

Bug: T296545
Change-Id: Ibdbf431fe7adb3cc3150aaf87d69b5989a1f0ac3