### PR TITLE
Parser: Fix extractSections() behavior for PHP >= 8.0

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -5652,7 +5652,10 @@ class Parser {
 		# Process section extraction flags
 		$flags = 0;
 		$sectionParts = explode( '-', $sectionId );
-		$sectionIndex = array_pop( $sectionParts );
+		// The section ID may either be a magic string such as 'new' (which should be treated as 0),
+		// or a numbered section ID in the format of "T-<section index>".
+		// Explicitly coerce the section index into a number accordingly. (T323373)
+		$sectionIndex = (int)array_pop( $sectionParts );
 		foreach ( $sectionParts as $part ) {
 			if ( $part === 'T' ) {
 				$flags |= Preprocessor::DOM_FOR_INCLUSION;
@@ -5662,7 +5665,7 @@ class Parser {
 		# Check for empty input
 		if ( strval( $text ) === '' ) {
 			# Only sections 0 and T-0 exist in an empty document
-			if ( $sectionIndex == 0 ) {
+			if ( $sectionIndex === 0 ) {
 				if ( $mode === 'get' ) {
 					return '';
 				}
@@ -5685,7 +5688,7 @@ class Parser {
 		$node = $root->getFirstChild();
 
 		# Find the target section
-		if ( $sectionIndex == 0 ) {
+		if ( $sectionIndex === 0 ) {
 			# Section zero doesn't nest, level=big
 			$targetLevel = 1000;
 		} else {

--- a/tests/phpunit/includes/api/query/ApiQueryRevisionsTest.php
+++ b/tests/phpunit/includes/api/query/ApiQueryRevisionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Revision\SlotRecord;
+
 /**
  * @group API
  * @group Database
@@ -44,5 +46,102 @@ class ApiQueryRevisionsTest extends ApiTestCase {
 				);
 			}
 		}
+	}
+
+	/**
+	 * @group medium
+	 */
+	public function testResolvesPrevNextInDiffto() {
+		$pageName = 'Help:' . __METHOD__;
+		$page = $this->getExistingTestPage( $pageName );
+		$user = $this->getTestUser()->getUser();
+
+		$revRecord = $page->newPageUpdater( $user )
+			->setContent( SlotRecord::MAIN, new WikitextContent( 'Some text' ) )
+			->saveRevision( CommentStoreComment::newUnsavedComment( 'inserting more content' ) );
+
+		[ $rvDiffToPrev ] = $this->doApiRequest( [
+			'action' => 'query',
+			'prop' => 'revisions',
+			'titles' => $pageName,
+			'rvdiffto' => 'prev',
+		] );
+
+		$this->assertSame(
+			$revRecord->getId(),
+			$rvDiffToPrev['query']['pages'][$page->getId()]['revisions'][0]['revid']
+		);
+		$this->assertSame(
+			$revRecord->getId(),
+			$rvDiffToPrev['query']['pages'][$page->getId()]['revisions'][0]['diff']['to']
+		);
+		$this->assertSame(
+			$revRecord->getParentId(),
+			$rvDiffToPrev['query']['pages'][$page->getId()]['revisions'][0]['diff']['from']
+		);
+
+		[ $rvDiffToNext ] = $this->doApiRequest( [
+			'action' => 'query',
+			'prop' => 'revisions',
+			'titles' => $pageName,
+			'rvdiffto' => 'next',
+			'rvdir' => 'newer'
+		] );
+
+		$this->assertSame(
+			$revRecord->getParentId(),
+			$rvDiffToNext['query']['pages'][$page->getId()]['revisions'][0]['revid']
+		);
+		$this->assertSame(
+			$revRecord->getId(),
+			$rvDiffToNext['query']['pages'][$page->getId()]['revisions'][0]['diff']['to']
+		);
+		$this->assertSame(
+			$revRecord->getParentId(),
+			$rvDiffToNext['query']['pages'][$page->getId()]['revisions'][0]['diff']['from']
+		);
+	}
+
+	/**
+	 * @dataProvider provideSectionNewTestCases
+	 * @param string $pageContent
+	 * @param string $expectedSectionContent
+	 * @group medium
+	 */
+	public function testSectionNewReturnsEmptyContentForPageWithSection(
+		$pageContent,
+		$expectedSectionContent
+	) {
+		$pageName = 'Help:' . __METHOD__;
+		$page = $this->getExistingTestPage( $pageName );
+		$user = $this->getTestUser()->getUser();
+		$revRecord = $page->newPageUpdater( $user )
+			->setContent( SlotRecord::MAIN, new WikitextContent( $pageContent ) )
+			->saveRevision( CommentStoreComment::newUnsavedComment( 'inserting content' ) );
+
+		[ $response ] = $this->doApiRequest( [
+			'action' => 'query',
+			'prop' => 'revisions',
+			'revids' => $revRecord->getId(),
+			'rvprop' => 'content|ids',
+			'rvslots' => 'main',
+			'rvsection' => 'new'
+		] );
+
+		$this->assertSame(
+			$expectedSectionContent,
+			$response['query']['pages'][$page->getId()]['revisions'][0]['slots']['main']['content']
+		);
+	}
+
+	public function provideSectionNewTestCases() {
+		yield 'page with existing section' => [
+			"==A section==\ntext",
+			''
+		];
+		yield 'page with no sections' => [
+			'This page has no sections',
+			'This page has no sections'
+		];
 	}
 }


### PR DESCRIPTION
PHP 8.0 changed the behavior of numeric comparisons such that non-numeric strings no longer weakly equal 0.[1] This breaks the logic in Parser::extractSections(), which was relying on the old comparison behavior for section indexes and in turn causes the revisions API to return a bogus 'nosuchsection' for error when called with rvsection=new.

Fix the logic by explicitly casting the section index to a number, which will yield the appropriate numeric section index for a numbered section index and 0 for a non-numeric section index (like 'new'). Also add test cases for the relevant API module.

--
[1] https://wiki.php.net/rfc/string_to_number_comparison

Change-Id: If32aa4d575cff66bd4eee56f9e3b0b0d9ba04fde
Bug: T323373