### PR TITLE
CATS-3534 Tabber is causing problem with section editing

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -5709,13 +5709,9 @@ class Parser {
 
 		if ( !$node ) {
 			# Not found
-			if ( $mode === 'get' ) {
-				if( $newText ) {
-					return $newText;
-				} else {
-				# According to CATS-3534 Tabber component can causing problem with section editing
-					return $text;
-				}
+			# According to CATS-3534 Tabber component can causing problem with section editing
+			if ( $mode === 'get' && $newText) {
+				return $newText;
 			} else {
 				return $text;
 			}

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -5710,7 +5710,12 @@ class Parser {
 		if ( !$node ) {
 			# Not found
 			if ( $mode === 'get' ) {
-				return $newText;
+				if( $newText ) {
+					return $newText;
+				} else {
+				# According to CATS-3534 Tabber component can causing problem with section editing
+					return $text;
+				}
 			} else {
 				return $text;
 			}


### PR DESCRIPTION
Tabber is causing problem with section editing, so if parser don't find section we send to editor whole text rater then error

