### PR TITLE
Revert "CATS-3647 Excluded special chars from url before link encode"

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -299,7 +299,7 @@ function wfUrlencode( $s ) {
 	}
 
 	if ( $needle === null ) {
-		$needle = [ '%3B', '%40', '%24', '%21', '%2A', '%28', '%29', '%2C', '%2F', '%7E', '%25', '%3F', '%3D' ];
+		$needle = [ '%3B', '%40', '%24', '%21', '%2A', '%28', '%29', '%2C', '%2F', '%7E' ];
 		if ( !isset( $_SERVER['SERVER_SOFTWARE'] ) ||
 			( strpos( $_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS/7' ) === false )
 		) {
@@ -310,7 +310,7 @@ function wfUrlencode( $s ) {
 	$s = urlencode( $s );
 	$s = str_ireplace(
 		$needle,
-		[ ';', '@', '$', '!', '*', '(', ')', ',', '/', '~', '%', '?', '=', ':' ],
+		[ ';', '@', '$', '!', '*', '(', ')', ',', '/', '~', ':' ],
 		$s
 	);
 


### PR DESCRIPTION
Reverts Wikia/mediawiki#68. This caused a regression for page names that contain a `?` and is probably the wrong place to resolve the original issue to start with.