### PR TITLE
PLATFORM-8072 | Fix XML dumps for content types with non-string getNativeData()

### DIFF
--- a/includes/export/XmlDumpWriter.php
+++ b/includes/export/XmlDumpWriter.php
@@ -562,7 +562,7 @@ class XmlDumpWriter {
 		if ( $content instanceof TextContent ) {
 			// HACK: For text based models, bypass the serialization step. This allows extensions (like Flow)
 			// that use incompatible combinations of serialization format and content model.
-			$data = $content->getNativeData();
+			$data = $content->getText();
 		} else {
 			$data = $content->serialize( $contentFormat );
 		}


### PR DESCRIPTION

In fdc3e9f9524d91a492bdc212486d4518991c0fe2, the code generating XML dumps was updated to support multi-content revisions. This refactor included a workaround for content types that are subclasses of TextContent to use getNativeData() rather than serialize(), apparently to satisfy the Flow extension.

However, this assumes that getNativeData() always returns a string. As demonstrated in T155582, this is not the case, which is one of the reasons why the method was deprecated. Notably, if a wiki has a custom content type defined whose getNativeData() returns a non-string value, and has pages using that content type, this breaks XML dump generation (dumpBackup.php) for that wiki and also makes those pages unexportable via Special:Export.

Fix it by using getText() instead of getNativeData(), which is the recommended migration path anyways per T155582. I am somewhat perplexed by the reference to Flow in the original code comment, because Flow's BoardContent does not seem to extend TextContent at all.