### PR TITLE
Reverse the query in migrateRevisionActorTemp.php

### DIFF
--- a/maintenance/migrateRevisionActorTemp.php
+++ b/maintenance/migrateRevisionActorTemp.php
@@ -48,16 +48,16 @@ class MigrateRevisionActorTemp extends LoggedUpdateMaintenance {
 		$updated = 0;
 		$start = (int)$this->getOption( 'start', 0 );
 		if ( $start > 0 ) {
-			$conds[] = 'rev_id >= ' . $dbw->addQuotes( $start );
+			$conds[] = 'revactor_rev >= ' . $dbw->addQuotes( $start );
 		}
 		while ( true ) {
 			$res = $dbw->newSelectQueryBuilder()
 				->select( [ 'rev_id', 'rev_actor', 'revactor_actor' ] )
-				->from( 'revision' )
-				->join( 'revision_actor_temp', null, 'rev_id=revactor_rev' )
+				->from( 'revision_actor_temp' )
+				->join( 'revision', null, 'rev_id=revactor_rev' )
 				->where( $conds )
 				->limit( $batchSize )
-				->orderBy( 'rev_id' )
+				->orderBy( 'revactor_rev' )
 				->caller( __METHOD__ )
 				->fetchResultSet();
 
@@ -89,7 +89,7 @@ class MigrateRevisionActorTemp extends LoggedUpdateMaintenance {
 
 			// @phan-suppress-next-line PhanTypeSuspiciousStringExpression last is not-null when used
 			$this->output( "... rev_id=$last, updated $updated\n" );
-			$conds = [ 'rev_id > ' . $dbw->addQuotes( $last ) ];
+			$conds = [ 'revactor_rev > ' . $dbw->addQuotes( $last ) ];
 
 			// Sleep between batches for replication to catch up
 			MediaWikiServices::getInstance()->getDBLoadBalancerFactory()->waitForReplication();


### PR DESCRIPTION
Sorting of the original query is not very optimized and is very slow to run because is done by the rev_id which besides unique index don't have other indexes that would optimize this query. `revactor_rev` has proper index that allows sorting by it. Therefore, reversing the query makes on DB like Marvel the process ~6x quicker and is probably even more significant for larger Databases.

Original code result:
```
Completed merge of revision_actor into the revision table, 10000 rows updated.

real    1m18.585s
user    0m2.647s
sys     0m0.757s
```

Code with the reversed query:
```
Completed merge of revision_actor into the revision table, 10000 rows updated.

real    0m15.776s
user    0m2.228s
sys     0m1.153s
```