### PR TITLE
MAIN-28662 | Vary RC user(talk) link cache on user name rather than ID

### DIFF
--- a/includes/changes/RCCacheEntryFactory.php
+++ b/includes/changes/RCCacheEntryFactory.php
@@ -107,7 +107,7 @@ class RCCacheEntryFactory {
 			 * unnecessary to process it for each RC record separately.
 			 */
 			$cacheEntry->usertalklink = $this->userTalkLinks->getWithSetCallback(
-				$cacheEntry->mAttribs['rc_user'],
+				$cacheEntry->mAttribs['rc_user_text'],
 				fn() => Linker::userToolLinks(
 					$cacheEntry->mAttribs['rc_user'],
 					$cacheEntry->mAttribs['rc_user_text'],
@@ -324,7 +324,7 @@ class RCCacheEntryFactory {
 			 * @see RCCacheEntryFactory::newFromRecentChange
 			 */
 			$userLink = $this->userLinks->getWithSetCallback(
-				$cacheEntry->mAttribs['rc_user'],
+				$cacheEntry->mAttribs['rc_user_text'],
 				fn() => Linker::userLink(
 					$cacheEntry->mAttribs['rc_user'],
 					$cacheEntry->mAttribs['rc_user_text'],


### PR DESCRIPTION
For anonymous users, the user ID is always zero, so it is possible for cached user links to be reused for different anonymous users after baf5c0a3b07603227d4498fba7898380ed911eda. This is not what we want, so use the user name as the cache key instead, which should be unique for both anonymous and registered users.