### PR TITLE
PLATFORM-8107 | Fix RC filter bookmark popup rendering

### DIFF
--- a/languages/i18n/en.json
+++ b/languages/i18n/en.json
@@ -1537,7 +1537,6 @@
 	"rcfilters-savedqueries-new-name-label": "Name",
 	"rcfilters-savedqueries-new-name-placeholder": "Describe the purpose of the filter",
 	"rcfilters-savedqueries-apply-label": "Create filter",
-	"rcfilters-savedqueries-apply-and-setdefault-label": "Create default filter",
 	"rcfilters-savedqueries-cancel-label": "Cancel",
 	"rcfilters-savedqueries-add-new-title": "Save current filter settings",
 	"rcfilters-savedqueries-already-saved": "These filters are already saved. Change your settings to create a new Saved Filter.",

--- a/languages/i18n/qqq.json
+++ b/languages/i18n/qqq.json
@@ -1790,7 +1790,6 @@
 	"rcfilters-savedqueries-new-name-label": "Label for the input that holds the name of the new saved filters in [[Special:RecentChanges]]\n{{Identical|Name}}",
 	"rcfilters-savedqueries-new-name-placeholder": "Placeholder for the input that holds the name of the new saved filters in [[Special:RecentChanges]]",
 	"rcfilters-savedqueries-apply-label": "Label for the button to apply saving a new filter setting in [[Special:RecentChanges]]. This is for a small popup, please try to use a short string.",
-	"rcfilters-savedqueries-apply-and-setdefault-label": "Label for the button to apply saving a new filter setting and set it as default in [[Special:RecentChanges]]. This is for a small popup, please try to use a short string.",
 	"rcfilters-savedqueries-cancel-label": "Label for the button to cancel the saving of a new quick link in [[Special:RecentChanges]]\n{{Identical|Cancel}}",
 	"rcfilters-savedqueries-add-new-title": "Title for the popup to add new quick link in [[Special:RecentChanges]]. This is for a small popup, please try to use a short string.",
 	"rcfilters-savedqueries-already-saved": "Title for the popup in [[Special:RecentChanges]] that indicates that current set of filters is already saved. This is for a small popup, please try to use a short string.",

--- a/resources/Resources.php
+++ b/resources/Resources.php
@@ -1905,7 +1905,6 @@ return [
 			'rcfilters-savedqueries-add-new-title',
 			'rcfilters-savedqueries-already-saved',
 			'rcfilters-savedqueries-apply-label',
-			'rcfilters-savedqueries-apply-and-setdefault-label',
 			'rcfilters-savedqueries-cancel-label',
 			'rcfilters-restore-default-filters',
 			'rcfilters-clear-all-filters',

--- a/resources/src/mediawiki.rcfilters/styles/mw.rcfilters.ui.SaveFiltersPopupButtonWidget.less
+++ b/resources/src/mediawiki.rcfilters/styles/mw.rcfilters.ui.SaveFiltersPopupButtonWidget.less
@@ -8,32 +8,10 @@
 		}
 
 		> .oo-ui-popupWidget-popup > .oo-ui-popupWidget-head {
-			position: relative;
-			height: auto;
-			padding: 1em;
-			// Icon width + icon left position (rounded to 0.5 to give a little extra margin)
-			padding-right: 1.875em + 0.5em;
-
-			> .oo-ui-buttonWidget {
-				top: 0.5em;
-			}
-
-			> .oo-ui-iconWidget {
-				vertical-align: top;
-			}
-
 			> .oo-ui-labelElement-label {
-				float: none;
-				display: inline-block;
-				// Label doesn't wrap without `max-width`. First setting a pretty arbitrary percentage value.
-				max-width: 80%;
-				// Overwrite it with `calc` reduced by icon width and left margin combined.
-				max-width: calc( ~'100% - 1.42857143em - 0.25em' );
-				margin: 0 0 0 0.25em;
 				font-size: 1.2em;
 				font-weight: bold;
 				line-height: 1.25;
-				vertical-align: top;
 			}
 		}
 	}

--- a/resources/src/mediawiki.rcfilters/ui/SaveFiltersPopupButtonWidget.js
+++ b/resources/src/mediawiki.rcfilters/ui/SaveFiltersPopupButtonWidget.js
@@ -31,6 +31,10 @@ var SaveFiltersPopupButtonWidget = function MwRcfiltersUiSaveFiltersPopupButtonW
 			classes: [ 'mw-rcfilters-ui-saveFiltersPopupButtonWidget-popup' ],
 			padded: true,
 			head: true,
+			// Make the popup slightly wider to accommodate titles and labels
+			// from languages that are longer than the original English ones.
+			// See T217304
+			width: 450,
 			icon: 'bookmark',
 			label: mw.msg( 'rcfilters-savedqueries-add-new-title' ),
 			$content: $popupContent
@@ -146,12 +150,7 @@ SaveFiltersPopupButtonWidget.prototype.onPopupReady = function () {
  */
 SaveFiltersPopupButtonWidget.prototype.onSetAsDefaultChange = function ( checked ) {
 	this.applyButton
-		.setIcon( checked ? 'pushPin' : null )
-		.setLabel( mw.msg(
-			checked ?
-				'rcfilters-savedqueries-apply-and-setdefault-label' :
-				'rcfilters-savedqueries-apply-label'
-		) );
+		.setIcon( checked ? 'pushPin' : null );
 };
 
 /**

--- a/resources/src/mediawiki.rcfilters/ui/SaveFiltersPopupButtonWidget.js
+++ b/resources/src/mediawiki.rcfilters/ui/SaveFiltersPopupButtonWidget.js
@@ -31,12 +31,11 @@ var SaveFiltersPopupButtonWidget = function MwRcfiltersUiSaveFiltersPopupButtonW
 			classes: [ 'mw-rcfilters-ui-saveFiltersPopupButtonWidget-popup' ],
 			padded: true,
 			head: true,
+			icon: 'bookmark',
 			label: mw.msg( 'rcfilters-savedqueries-add-new-title' ),
 			$content: $popupContent
 		}
 	}, config ) );
-	// // HACK: Add an icon to the popup head label
-	this.popup.$head.prepend( ( new OO.ui.IconWidget( { icon: 'bookmark' } ) ).$element );
 
 	this.input = new OO.ui.TextInputWidget( {
 		placeholder: mw.msg( 'rcfilters-savedqueries-new-name-placeholder' )


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/PLATFORM-8107
* https://phabricator.wikimedia.org/T217304
* https://phabricator.wikimedia.org/T312169

## Description
Currently, if the popup will go outside the view, on scroll will go blank and also will stretch indefinitely. Bigger starting width seems to fix the issue, as the main reasons for the problem to occur is that our buttons are too big for the popup and therefore is calculated wrong.

## Acceptance Criteria
- [ ] test for new code.

## Who might be interested
@Wikia/wiki-platform 