### PR TITLE
UXFCP-3983 fix: GP slideshow when the image is not found because of w…

### DIFF
--- a/resources/src/mediawiki.page.gallery.slideshow.js
+++ b/resources/src/mediawiki.page.gallery.slideshow.js
@@ -249,6 +249,9 @@
 		$imageLi.addClass( 'slideshow-current' );
 
 		this.$thumbnail = $imageLi.find( 'img' );
+
+		this.$video = $imageLi.find( 'video' );
+
 		if ( this.$thumbnail.length ) {
 			// 2. Create and show thumbnail
 			this.$img = $( '<img>' ).attr( {
@@ -261,6 +264,14 @@
 				.append( this.$img );
 
 			this.$imgContainer.empty().append( $imgLink );
+		} else if (this.$video.length) {
+
+			const clonedVideo = this.$video.clone();
+
+			clonedVideo.width('auto');
+			clonedVideo.height('auto');
+
+			this.$imgContainer.empty().append( clonedVideo );
 		} else {
 			// 2b. No image found (e.g. file doesn't exist)
 			this.$imgContainer.text( $imageLi.find( '.thumb' ).text() );
@@ -341,10 +352,19 @@
 			api = new mw.Api();
 			// TODO: This supports only gallery of images
 			title = mw.Title.newFromImg( $img );
+
+			title = title.toString();
+
+			if ($img.data('image-name')) {
+				title = 'File:' + $img.data('image-name');
+			} else if ($img.data('video-name')) {
+				title = 'File:' + $img.data('video-name');
+			}
+
 			params = {
 				action: 'query',
 				formatversion: 2,
-				titles: title.toString(),
+				titles: title,
 				prop: 'imageinfo',
 				iiprop: 'url'
 			};


### PR DESCRIPTION
 GP slideshow when the image is not found because of wrong title for the files without scale-to-width param

It always takes File:Latest?cb=number