### PR TITLE
PLATFORM-8453| user page as a main page

### DIFF
--- a/includes/skins/SkinTemplate.php
+++ b/includes/skins/SkinTemplate.php
@@ -1309,9 +1309,10 @@ class SkinTemplate extends Skin {
 				// * nstab-category
 				// * nstab-<subject namespace key>
 				$subjectMsg = [ "nstab-$subjectId" ];
-			}
-			if ( $subjectPage->isMainPage() ) {
-				array_unshift( $subjectMsg, 'nstab-mainpage' );
+
+				if ( $subjectPage->isMainPage() ) {
+					array_unshift( $subjectMsg, 'nstab-mainpage' );
+				}
 			}
 
 			$associatedPages[$subjectId] = $this->tabAction(


### PR DESCRIPTION
Fix that allows to have user page as a Main Page for a wiki. Currently it crashes since this case was not taken into account.