### PR TITLE
WebRequest: Fix PHP 8.1 deprecations in getFuzzyBool()

### DIFF
--- a/includes/WebRequest.php
+++ b/includes/WebRequest.php
@@ -672,9 +672,13 @@ class WebRequest {
 	 * @param bool $default
 	 * @return bool
 	 */
-	public function getFuzzyBool( $name, $default = false ) {
-		return $this->getBool( $name, $default )
-			&& strcasecmp( $this->getRawVal( $name ), 'false' ) !== 0;
+	public function getFuzzyBool( $name, $default = false ): bool {
+		$value = $this->getRawVal( $name );
+		if ( $value === null ) {
+			return (bool)$default;
+		}
+
+		return $value && strcasecmp( $value, 'false' ) !== 0;
 	}
 
 	/**

--- a/tests/phpunit/includes/WebRequestTest.php
+++ b/tests/phpunit/includes/WebRequestTest.php
@@ -341,6 +341,11 @@ class WebRequestTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( false, $req->getFuzzyBool( 'z' ), 'Not found' );
 	}
 
+	public function testGetFuzzyBoolDefaultTrue() {
+		$req = $this->mockWebRequest();
+		$this->assertTrue( $req->getFuzzyBool( 'z', true ), 'Not found, default true' );
+	}
+
 	/**
 	 * @covers WebRequest::getCheck
 	 */


### PR DESCRIPTION
WebRequest::getFuzzyBool() will emit a deprecation warning on PHP 8.1 or newer if the parameter to be fetched is absent and the $default value is set to `true`, because strcasecmp() no longer accepts nulls. Fix it by returning out if the parameter is wholly absent and add a test for this scenario.

Bug: T351088
Change-Id: I85bbfec6aabef4e85859a76b6e50c80781024ae5