### PR TITLE
Declare Status::apiHookResult

### DIFF
--- a/includes/Status.php
+++ b/includes/Status.php
@@ -45,6 +45,13 @@ class Status extends StatusValue {
 	/** @var callable|false */
 	public $cleanCallback = false;
 
+	/**
+	 * Used by some extensions (ConfirmEdit) to customize API error responses for edits.
+	 * @internal Only used by ConfirmEdit and the ApiEditPage class
+	 * @var array|null
+	 */
+	public $apiHookResult;
+
 	/** @var MessageLocalizer|null */
 	protected $messageLocalizer;
 


### PR DESCRIPTION
This is only used by ConfirmEdit and Phalanx to customize API error rendering for API edits. Let's declare the property explicitly to avoid errors on PHP 8.2. We can remove this if upstream fixes it later in a different way.