### PR TITLE
PLATFORM-8972| ExternalStoreDB avoid primary DB connection in read only mode

### DIFF
--- a/includes/externalstore/ExternalStoreDB.php
+++ b/includes/externalstore/ExternalStoreDB.php
@@ -317,7 +317,7 @@ class ExternalStoreDB extends ExternalStoreMedium {
 			[ 'blob_id' => $id ],
 			__METHOD__
 		);
-		if ( $ret === false ) {
+		if ( $ret === false && !$this->isReadOnly( $cluster ) ) {
 			// Try the primary DB
 			$this->logger->warning( __METHOD__ . ": primary DB fallback on $cacheID" );
 			$scope = $this->lbFactory->getTransactionProfiler()->silenceForScope();


### PR DESCRIPTION
It seems that ExternalStoreDB when fetching blobs fall backs to primary DB even when read only is active which causes some errors when there is no primary DB available.