### PR TITLE
PLATFORM-10554 Remove diverging paths for CSS sanitization

### DIFF
--- a/includes/parser/Sanitizer.php
+++ b/includes/parser/Sanitizer.php
@@ -705,28 +705,13 @@ class Sanitizer {
 	 * @return string
 	 */
 	public static function checkCss( $value ) {
-		global $wgEnableHydraFeatures;
 		$value = self::normalizeCss( $value );
 
 		// Reject problematic keywords and control characters
 		if ( preg_match( '/[\000-\010\013\016-\037\177]/', $value ) ||
 			strpos( $value, \UtfNormal\Constants::UTF8_REPLACEMENT ) !== false ) {
 			return '/* invalid control char */';
-		/** Fandom change begin -- we need to remove "| var\s*\(" on GP wikis **/
-		} elseif ( empty( $wgEnableHydraFeatures ) && preg_match(
-			'! expression
-				| filter\s*:
-				| accelerator\s*:
-				| -o-link\s*:
-				| -o-link-source\s*:
-				| -o-replace\s*:
-				| url\s*\(
-				| image\s*\(
-				| image-set\s*\(
-				| attr\s*\([^)]+[\s,]+url
-			!ix', $value ) ) {
-			return '/* insecure input */';
-		} elseif ( !empty( $wgEnableHydraFeatures ) && preg_match(
+		} elseif ( preg_match(
 			'! expression
 				| accelerator\s*:
 				| -o-link\s*:
@@ -740,7 +725,6 @@ class Sanitizer {
 			!ix', $value ) ) {
 			return '/* insecure input */';
 		}
-		/** Fandom change end **/
 		return $value;
 	}
 


### PR DESCRIPTION
In upstream MW 1.43, there was a [change](https://phabricator.wikimedia.org/T308160) allowing the `filter` in style.

This only affects Gamepedia wikis right now:
* When building UCP, we’ve introduced a branch in logic because Gamepedia wikis allowed var and Fandom did not (see: https://fandom.atlassian.net/browse/GPUCP-352).
* During this upgrade, Fandom branch in logic was not affected by MW 1.43.

We can safely change the Fandom branch in logic to allow `filter`, in MW 1.39 Upgrade we’ve allowed var on Fandom as we pulled in our MW contribution: https://phabricator.wikimedia.org/T288201, so I’d rather remove this branch in logic altogether. That will reduce unnecessary complexity and address the issue.

This reverts commit c47b14f9d4e925c3350d8c6722cfaf3095deada1 which introduces the branches in logic, making `filter` correctly work on all wikis.