### PR TITLE
Save file name in 7zip archive

### DIFF
--- a/includes/export/Dump7ZipOutput.php
+++ b/includes/export/Dump7ZipOutput.php
@@ -50,8 +50,9 @@ class Dump7ZipOutput extends DumpPipeOutput {
 	 * @return string
 	 */
 	private function setup7zCommand( $file ) {
-		$command = "7za a -bd -si -mx=";
-		$command .= Shell::escape( (string)$this->compressionLevel ) . ' ';
+		$command = "7za a -bd ";
+		$command .= "-si" . Shell::escape( basename( $file ) ) . ' ';
+		$command .= "-mx=" . Shell::escape( (string)$this->compressionLevel ) . ' ';
 		$command .= Shell::escape( $file );
 		// Suppress annoying useless crap from p7zip
 		// Unfortunately this could suppress real error messages too

--- a/includes/export/Dump7ZipOutput.php
+++ b/includes/export/Dump7ZipOutput.php
@@ -51,7 +51,7 @@ class Dump7ZipOutput extends DumpPipeOutput {
 	 */
 	private function setup7zCommand( $file ) {
 		$command = "7za a -bd ";
-		$command .= "-si" . Shell::escape( basename( $file ) ) . ' ';
+		$command .= "-si" . Shell::escape( preg_replace( '/\\.7z$/', '', basename( $file ) ) ) . ' ';
 		$command .= "-mx=" . Shell::escape( (string)$this->compressionLevel ) . ' ';
 		$command .= Shell::escape( $file );
 		// Suppress annoying useless crap from p7zip


### PR DESCRIPTION
Setting the file name in 7zip archive makes the archive more compatible with various readers, eg. windows 11 or macOS built-in 7zip support.

New bug: On *nix systems files are extracted without any permissions from such archive.