### PR TITLE
UGC-7320: FileRepo: Add 'userAgent' option in ForeignAPIRepo for wgForeignFileR…

### DIFF
--- a/includes/filerepo/ForeignAPIRepo.php
+++ b/includes/filerepo/ForeignAPIRepo.php
@@ -85,6 +85,9 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 	/** @var string */
 	private $mApiBase;
 
+	/** @var string */
+	private $userAgent;
+
 	/**
 	 * @param array|null $info
 	 */
@@ -104,6 +107,9 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 		}
 		if ( isset( $info['apiMetadataExpiry'] ) ) {
 			$this->apiMetadataExpiry = $info['apiMetadataExpiry'];
+		}
+		if ( isset( $info['userAgent'] ) ) {
+			$this->userAgent = $info['userAgent'];
 		}
 		if ( !$this->scriptDirUrl ) {
 			// hack for description fetches
@@ -418,7 +424,7 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 			/* There is a new Commons file, or existing thumbnail older than a month */
 		}
 
-		$thumb = self::httpGet( $foreignUrl, 'default', [], $mtime );
+		$thumb = $this->httpGet( $foreignUrl, 'default', [], $mtime );
 		if ( !$thumb ) {
 			wfDebug( __METHOD__ . " Could not download thumb" );
 
@@ -487,9 +493,12 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 	 * The user agent the ForeignAPIRepo will use.
 	 * @return string
 	 */
-	public static function getUserAgent() {
-		return MediaWikiServices::getInstance()->getHttpRequestFactory()->getUserAgent() .
-			" ForeignAPIRepo/" . self::VERSION;
+	public function getUserAgent() {
+		$mediaWikiVersion = MediaWikiServices::getInstance()->getHttpRequestFactory()->getUserAgent();
+		$classVersion = self::VERSION;
+		$contactUrl = MediaWikiServices::getInstance()->getUrlUtils()->getCanonicalServer();
+		$extra = $this->userAgent !== null ? ' ' . $this->userAgent : '';
+		return "$mediaWikiVersion ($contactUrl) ForeignAPIRepo/$classVersion" . $extra;
 	}
 
 	/**
@@ -532,7 +541,7 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 	 * @param int|false &$mtime Resulting Last-Modified UNIX timestamp if received
 	 * @return string|false
 	 */
-	public static function httpGet(
+	public function httpGet(
 		$url, $timeout = 'default', $options = [], &$mtime = false
 	) {
 		$options['timeout'] = $timeout;
@@ -548,7 +557,7 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 			$options['timeout'] = 'default';
 		}
 
-		$options['userAgent'] = self::getUserAgent();
+		$options['userAgent'] = $this->getUserAgent();
 
 		$req = MediaWikiServices::getInstance()->getHttpRequestFactory()
 			->create( $url, $options, __METHOD__ );
@@ -563,7 +572,7 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 			$logger = LoggerFactory::getInstance( 'http' );
 			$logger->warning(
 				$status->getWikiText( false, false, 'en' ),
-				[ 'caller' => 'ForeignAPIRepo::httpGet' ]
+				[ 'caller' => __METHOD__ ]
 			);
 
 			return false;
@@ -599,7 +608,7 @@ class ForeignAPIRepo extends FileRepo implements IForeignRepoWithMWApi {
 			$this->wanCache->makeGlobalKey( "filerepo-$attribute", sha1( $url ) ),
 			$cacheTTL,
 			function ( $curValue, &$ttl ) use ( $url ) {
-				$html = self::httpGet( $url, 'default', [], $mtime );
+				$html = $this->httpGet( $url, 'default', [], $mtime );
 				// FIXME: This should use the mtime from the api response body
 				// not the mtime from the last-modified header which usually is not set.
 				if ( $html !== false ) {


### PR DESCRIPTION
…epos

For large wiki farms like Miraheze, it makes traffic attribution [0] easier if the user-agent shares a common token (like "Miraheze") across all wikis, instead of specifying only the individual site URL, given many different subdomains and vanity domains.

Convert both httpGet() and getUserAgent() static functions to plain functions. There doesn't appear to be any use of them outside this class, so it seems safe to just make them non static and be able to backport to stable branches.

[0] https://wikitech.wikimedia.org/wiki/Bot_traffic

Change-Id: I90866332dd65b172687084f96d6f11fc0ee4171d