### PR TITLE
PLATFORM-11790| undo Parser::extractBody() breaking change.

### DIFF
--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -6521,7 +6521,13 @@ class Parser {
 		$text = preg_replace( '!^(?>.*?<body)[^>]*+>!s', '', $text, 1 );
 		if ( $text === null ) {
 			// T399064: this should never happen
-			throw new RuntimeException( 'Regex failed: ' . preg_last_error() );
+			// Fandom-change: start
+			// This exception is breaking Visual Editor in some cases, upstream is tracking this in:
+			// * https://phabricator.wikimedia.org/T388729
+			// * https://phabricator.wikimedia.org/T399064
+			// throw new RuntimeException( 'Regex failed: ' . preg_last_error() );
+			return $text;
+			// Fandom-change: stop
 		}
 		$text = preg_replace( '!</body>\s*+</html>\s*+$!', '', $text, 1 );
 		return $text;

--- a/includes/parser/Parser.php
+++ b/includes/parser/Parser.php
@@ -6518,18 +6518,12 @@ class Parser {
 	 * @unstable
 	 */
 	public static function extractBody( string $text ): string {
-		$text = preg_replace( '!^(?>.*?<body)[^>]*+>!s', '', $text, 1 );
-		if ( $text === null ) {
-			// T399064: this should never happen
-			// Fandom-change: start
-			// This exception is breaking Visual Editor in some cases, upstream is tracking this in:
-			// * https://phabricator.wikimedia.org/T388729
-			// * https://phabricator.wikimedia.org/T399064
-			// throw new RuntimeException( 'Regex failed: ' . preg_last_error() );
-			return $text;
-			// Fandom-change: stop
-		}
-		$text = preg_replace( '!</body>\s*+</html>\s*+$!', '', $text, 1 );
+		// Fandom-change: start
+		// The exception thrown in MW 1.43.8 is breaking Visual Editor in some cases, upstream is tracking this in:
+		// * https://phabricator.wikimedia.org/T388729
+		// * https://phabricator.wikimedia.org/T399064
+		$text = preg_replace( '!^.*?<body[^>]*>!s', '', $text, 1 );
+		$text = preg_replace( '!</body>\s*</html>\s*$!', '', $text, 1 );
 		return $text;
 	}
 


### PR DESCRIPTION
This exception is breaking Visual Editor on some pages. Until upstream fixes this (they are aware) we need to revert back to previous behaviour.